### PR TITLE
Catch TException on open and display info

### DIFF
--- a/AiravataWrapper.php
+++ b/AiravataWrapper.php
@@ -72,7 +72,14 @@ class AiravataWrapper implements AiravataWrapperInterface
         $this->transport->setSendTimeout($this->airavataconfig['AIRAVATA_TIMEOUT']);
 
         $protocol = new TBinaryProtocol($this->transport);
-        $this->transport->open();
+        try {
+            $this->transport->open();
+        } catch (TException $te) {
+            echo "Error trying to submit the job<br>";
+            echo $te->getMessage() . "<br>";
+            echo "Possibly the site is down or the certificate is expired.";
+        }
+            
         $this->airavataclient = new AiravataClient($protocol);
 
         $this->authToken = new AuthzToken();


### PR DESCRIPTION
 - When the certs expire or a connection can't be made, currently the user sees nothing but a blank page as the php dies "PHP message: PHP Fatal error:  Uncaught Thrift\\Exception\\TException:"
 - This, at least, gives them some sort of feedback.
   - later will add email to admins when email has been redone in the UltraScan LIMS