### PR TITLE
Intuitive message for when resource not assigned

### DIFF
--- a/AiravataWrapper.php
+++ b/AiravataWrapper.php
@@ -322,7 +322,7 @@ class AiravataWrapper implements AiravataWrapperInterface
           if ($comRescheduling != null && !empty($comRescheduling->resourceHostId)) {
               return select_compute_resource_name($this->airavataconfig, $comRescheduling->resourceHostId);
           } else {
-              return "Resource not yet assigned";
+              return ' Resource not yet assigned ';
           }
         } catch (AiravataSystemException $ase) {
             echo $ase->getMessage();

--- a/AiravataWrapper.php
+++ b/AiravataWrapper.php
@@ -319,8 +319,10 @@ class AiravataWrapper implements AiravataWrapperInterface
         try {
           $experimentModel =   $this->airavataclient->getExperiment($this->authToken,$experimentId);
           $comRescheduling = $experimentModel->userConfigurationData->computationalResourceScheduling;
-          if ($comRescheduling != null) {
+          if ($comRescheduling != null && !empty($comRescheduling->resourceHostId)) {
               return select_compute_resource_name($this->airavataconfig, $comRescheduling->resourceHostId);
+          } else {
+              return "Resource not yet assigned";
           }
         } catch (AiravataSystemException $ase) {
             echo $ase->getMessage();


### PR DESCRIPTION
When the resourceHostId was not set it would return a default resource giving the impression that a resource had been assigned. 